### PR TITLE
Add thermostat service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It supports both long and short polling. The following device services are imple
 * ```PrivacyMode```
 * ```CameraNotification```
 * ```IntrusionDetectionControl```
+* ```Thermostat```
 
 The following device models are implemented, using the above services:
 

--- a/boschshcpy/services_impl.py
+++ b/boschshcpy/services_impl.py
@@ -473,6 +473,20 @@ class BatteryLevelService(SHCDeviceService):
         print(f"    warningLevel             : {self.warningLevel}")
 
 
+class ThermostatService(SHCDeviceService):
+    class State(Enum):
+        ON = "ON"
+        OFF = "OFF"
+
+    @property
+    def value(self) -> State:
+        return self.State(self.state["childLock"])
+
+    def summary(self):
+        super().summary()
+        print(f"    childLock                : {self.value}")
+
+
 SERVICE_MAPPING = {
     "TemperatureLevel": TemperatureLevelService,
     "HumidityLevel": HumidityLevelService,
@@ -496,6 +510,7 @@ SERVICE_MAPPING = {
     "AirQualityLevel": AirQualityLevelService,
     "SurveillanceAlarm": SurveillanceAlarmService,
     "BatteryLevel": BatteryLevelService,
+    "Thermostat": ThermostatService,
 }
 
 #    "SmokeDetectionControl": SmokeDetectionControlService,


### PR DESCRIPTION
Added the thermostat service to get familiar with the code. Here an example output from `SHCDevice.summary()`:
```
THB Wall Thermostat:
Device: hdm:HomeMaticIP:xxx
  Name          : Thermostat
  Manufacturer  : BOSCH
  Model         : THB
  Room          : hz_2
  Serial        : xxx
  Profile       : GENERIC
  Device Service: Thermostat
    State: {'@type': 'childLockState', 'childLock': 'ON'}
    Path:  /devices/hdm:HomeMaticIP:xxx/services/Thermostat
    childLock                : State.ON
  Device Service: BatteryLevel
    State: None
    Path:  /devices/hdm:HomeMaticIP:xxx/services/BatteryLevel
    warningLevel             : State.OK
  Device Service: TemperatureLevel
    State: {'@type': 'temperatureLevelState', 'temperature': 21.6}
    Path:  /devices/hdm:HomeMaticIP:xxx/services/TemperatureLevel
    Temperature              : 21.6
  Device Service: HumidityLevel
    State: {'@type': 'humidityLevelState', 'humidity': 44.0}
    Path:  /devices/hdm:HomeMaticIP:xxx/services/HumidityLevel
    Humidity              : 44.0
```