### PR TITLE
feat(device): add smart plug compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following device models are implemented, using the above services:
 * ```ShutterContact```
 * ```ShutterControl```
 * ```SmartPlug```
+* ```SmartPlugCompact```
 * ```LightControl```
 * ```SmokeDetector```
 * ```CameraEyes```

--- a/boschshcpy/__init__.py
+++ b/boschshcpy/__init__.py
@@ -10,6 +10,7 @@ from .device_helper import (
     SHCShutterContact,
     SHCShutterControl,
     SHCSmartPlug,
+    SHCSmartPlugCompact,
     SHCSmokeDetector,
     SHCThermostat,
     SHCTwinguard,

--- a/boschshcpy/device_helper.py
+++ b/boschshcpy/device_helper.py
@@ -13,6 +13,7 @@ from .models_impl import (
     SHCShutterContact,
     SHCShutterControl,
     SHCSmartPlug,
+    SHCSmartPlugCompact,
     SHCSmokeDetector,
     SHCThermostat,
     SHCTwinguard,
@@ -64,6 +65,12 @@ class SHCDeviceHelper:
         if "BSM" in SUPPORTED_MODELS:
             devices.extend(self._devices_by_model["BSM"].values())
         return devices
+
+    @property
+    def smart_plugs_compact(self) -> typing.Sequence[SHCSmartPlugCompact]:
+        if "PLUG_COMPACT" not in SUPPORTED_MODELS:
+            return []
+        return list(self._devices_by_model['PLUG_COMPACT'].values())
 
     @property
     def smoke_detectors(self) -> typing.Sequence[SHCSmokeDetector]:

--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -117,6 +117,55 @@ class SHCSmartPlug(SHCDevice):
         super().summary()
 
 
+class SHCSmartPlugCompact(SHCDevice):
+    from .services_impl import (
+        PowerMeterService,
+        PowerSwitchProgramService,
+        PowerSwitchService,
+        CommunicationQualityService
+    )
+
+    def __init__(self, api, raw_device):
+        super().__init__(api, raw_device)
+
+        self._powerswitch_service = self.device_service("PowerSwitch")
+        self._powerswitchprogram_service = self.device_service("PowerSwitchProgram")
+        self._powermeter_service = self.device_service("PowerMeter")
+        self._communicationquality_service = self.device_service("CommunicationQuality")
+
+    @property
+    def state(self) -> PowerSwitchService.State:
+        return self._powerswitch_service.value
+
+    @state.setter
+    def state(self, state: bool):
+        self._powerswitch_service.put_state_element(
+            "switchState", "ON" if state else "OFF"
+        )
+
+    @property
+    def energyconsumption(self) -> float:
+        return self._powermeter_service.energyconsumption
+
+    @property
+    def powerconsumption(self) -> float:
+        return self._powermeter_service.powerconsumption
+
+    @property
+    def communicationquality(self) -> float:
+        return self._communicationquality_service.value
+
+    def update(self):
+        self._powerswitch_service.short_poll()
+        self._powerswitchprogram_service.short_poll()
+        self._powermeter_service.short_poll()
+        self._communicationquality_service.short_poll()
+
+    def summary(self):
+        print(f"PLUG_COMPACT SmartPlugCompact:")
+        super().summary()
+
+
 class SHCShutterControl(SHCDevice):
     from .services_impl import ShutterControlService
 
@@ -703,6 +752,7 @@ MODEL_MAPPING = {
     "BBL": SHCShutterControl,
     "PSM": SHCSmartPlug,
     "BSM": SHCSmartPlug,  # uses same impl as PSM
+    "PLUG_COMPACT": SHCSmartPlugCompact,
     "SD": SHCSmokeDetector,
     "CAMERA_EYES": SHCCameraEyes,
     "CAMERA_360": SHCCamera360,

--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -152,7 +152,7 @@ class SHCSmartPlugCompact(SHCDevice):
         return self._powermeter_service.powerconsumption
 
     @property
-    def communicationquality(self) -> float:
+    def communicationquality(self) -> CommunicationQualityService.State:
         return self._communicationquality_service.value
 
     def update(self):


### PR DESCRIPTION
Add support for Smart Plug Compact with ZigBee 3.0.

Output of `SHCDevice.summary`

```
PLUG_COMPACT SmartPlugCompact:
Device: hdm:ZigBee:12345
  Name          : Some Name
  Manufacturer  : BOSCH
  Model         : PLUG_COMPACT
  Room          : hz_6
  Serial        : 847127FFFE99DB9B
  Profile       : GENERIC
  Status        : AVAILABLE
  ParentDevice  : None
  ChildDevices  : []
  Device Service: CommunicationQuality
    State: {'@type': 'communicationQualityState', 'quality': 'GOOD'}
    Path:  /devices/hdm:ZigBee:12345/services/CommunicationQuality
    quality                  : State.GOOD
  Device Service: PowerMeter
    State: {'@type': 'powerMeterState', 'powerConsumption': 0.0, 'energyConsumption': 0.0}
    Path:  /devices/hdm:ZigBee:12345/services/PowerMeter
    powerConsumption         : 0.0
    energyConsumption        : 0.0
  Device Service: PowerSwitch
    State: {'@type': 'powerSwitchState', 'switchState': 'OFF', 'automaticPowerOffTime': 0}
    Path:  /devices/hdm:ZigBee:12345/services/PowerSwitch
    switchState              : State.OFF
    automaticPowerOffTime    : 0
  Device Service: PowerSwitchProgram
    State: {'@type': 'powerSwitchProgramState', 'operationMode': 'MANUAL', 'schedule': {'profiles': []}}
    Path:  /devices/hdm:ZigBee: 12345/services/PowerSwitchProgram
    operationMode            : State.MANUAL
```