### PR TITLE
Add cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,10 @@ setup(
         "License :: OSI Approved :: BSD License",
     ],
     python_requires=">=3.7",
-    install_requires=["requests>=2.22", "zeroconf>=0.28.0", "getmac==0.8.2"],
+    install_requires=[
+        "cryptography",
+        "getmac==0.8.2",
+        "requests>=2.22",
+        "zeroconf>=0.28.0",
+    ],
 )


### PR DESCRIPTION
`cryptography` is a [requirement](https://github.com/tschamm/boschshcpy/blob/master/boschshcpy/generate_cert.py#L3-L7).