### PR TITLE
feat: add support for ShutterContact II

### DIFF
--- a/boschshcpy/device_helper.py
+++ b/boschshcpy/device_helper.py
@@ -62,9 +62,14 @@ class SHCDeviceHelper:
 
     @property
     def shutter_contacts(self) -> typing.Sequence[SHCShutterContact]:
-        if "SWD" not in SUPPORTED_MODELS:
-            return []
-        return list(self._devices_by_model["SWD"].values())
+        devices = []
+        if "SWD" in SUPPORTED_MODELS:
+            devices.extend(self._devices_by_model["SWD"].values())
+        if "SWD2" in SUPPORTED_MODELS:
+            devices.extend(self._devices_by_model["SWD2"].values())
+        if "SWD2_PLUS" in SUPPORTED_MODELS:
+            devices.extend(self._devices_by_model["SWD2_PLUS"].values())
+        return devices
 
     @property
     def shutter_controls(self) -> typing.Sequence[SHCShutterControl]:

--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -273,7 +273,7 @@ class SHCShutterContact(SHCBatteryDevice):
         super().update()
 
     def summary(self):
-        print(f"SWD ShutterContact:")
+        print(f"SWD / SWD2 / SWD2_PLUS ShutterContact:")
         super().summary()
 
 
@@ -865,6 +865,8 @@ class SHCWaterLeakageSensor(SHCBatteryDevice):
 
 MODEL_MAPPING = {
     "SWD": SHCShutterContact,
+    "SWD2": SHCShutterContact,
+    "SWD2_PLUS": SHCShutterContact,
     "BBL": SHCShutterControl,
     "PSM": SHCSmartPlug,
     "BSM": SHCLightSwitch,


### PR DESCRIPTION
This adds support for the new ShutterContact v2 & v2 Plus: https://www.bosch-smarthome.com/de/de/produkte/geraete/tuer-fensterkontakt/

Note that this does not add features for the new `Bypass` and `VibrationSensor` services supported by the new devices. 