### PR TITLE
include support for "Bosch light / shutter control II" (deviceModel: "MICROMODULE_LIGHT_CONTROL")

### DIFF
--- a/boschshcpy/device_helper.py
+++ b/boschshcpy/device_helper.py
@@ -82,9 +82,12 @@ class SHCDeviceHelper:
     
     @property
     def light_switches(self) -> typing.Sequence[SHCLightSwitch]:
-        if "BSM" not in SUPPORTED_MODELS:
-            return []
-        return list(self._devices_by_model["BSM"].values())
+        devices = []
+        if "BSM" in SUPPORTED_MODELS:
+            devices.extend(self._devices_by_model["BSM"].values())
+        if "MICROMODULE_LIGHT_ATTACHED" in SUPPORTED_MODELS:
+            devices.extend(self._devices_by_model["MICROMODULE_LIGHT_ATTACHED"].values())
+        return devices        
 
     @property
     def smart_plugs(self) -> typing.Sequence[SHCSmartPlug]:

--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -217,7 +217,7 @@ class SHCLightSwitch(SHCDevice):
         self._powermeter_service.short_poll()
 
     def summary(self):
-        print(f"BSM LightSwitch:")
+        print(f"BSM / MICROMODULE_LIGHT_CONTROL LightSwitch:")
         super().summary()
 
 
@@ -871,6 +871,7 @@ MODEL_MAPPING = {
     "MICROMODULE_SHUTTER": SHCShutterControl,
     "PSM": SHCSmartPlug,
     "BSM": SHCLightSwitch,
+    "MICROMODULE_LIGHT_AVAILABLE": SHCLightSwitch,
     "PLUG_COMPACT": SHCSmartPlugCompact,
     "SD": SHCSmokeDetector,
     "SMOKE_DETECTOR2": SHCSmokeDetector,

--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -871,7 +871,7 @@ MODEL_MAPPING = {
     "MICROMODULE_SHUTTER": SHCShutterControl,
     "PSM": SHCSmartPlug,
     "BSM": SHCLightSwitch,
-    "MICROMODULE_LIGHT_AVAILABLE": SHCLightSwitch,
+    "MICROMODULE_LIGHT_ATTACHED": SHCLightSwitch,
     "PLUG_COMPACT": SHCSmartPlugCompact,
     "SD": SHCSmokeDetector,
     "SMOKE_DETECTOR2": SHCSmokeDetector,


### PR DESCRIPTION
As I installed another "Bosch light / shutter control II" in my home, I used the opportunity to create a Postman excerpt with a configuration as light switch (as initial setup allows to configure the switch as either light or shutter control) before.

I tried to include support for "Bosch light / shutter control II" (deviceModel: "MICROMODULE_LIGHT_CONTROL").

Excerpts from Postman:

```
{
    "@type": "device",
    "rootDeviceId": "xx-xx-xx-xx-xx-xx",
    "id": "hdm:ZigBee:dc8exxxxxxxxxxxx",
    "deviceServiceIds": [
        "CommunicationQuality",
        "PowerMeter",
        "ElectricalFaults",
        "SwitchConfiguration"
    ],
    "manufacturer": "BOSCH",
    "deviceModel": "MICROMODULE_LIGHT_CONTROL",
    "serial": "DC8Exxxxxxxxxxxx",
    "profile": "GENERIC",
    "name": "LightMM_dc8exxxxxxxxxxxx",
    "status": "AVAILABLE",
    "childDeviceIds": [
        "hdm:ZigBee:dc8exxxxxxxxxxxx#3",
        "hdm:ZigBee:dc8exxxxxxxxxxxx#2"
    ]
}
```

This is a configuration for two connected lights:
```
    {
        "@type": "device",
        "rootDeviceId": "xx-xx-xx-xx-xx-xx",
        "id": "hdm:ZigBee:dc8exxxxxxxxxxxx#3",
        "deviceServiceIds": [
            "PowerSwitch",
            "ChildProtection",
            "PowerSwitchProgram"
        ],
        "manufacturer": "BOSCH",
        "roomId": "hz_8",
        "deviceModel": "MICROMODULE_LIGHT_ATTACHED",
        "serial": "DC8EXXXXXXXXXXXX",
        "profile": "GENERIC",
        "iconId": "icon_mm_light_generic",
        "name": "test2",
        "status": "AVAILABLE",
        "parentDeviceId": "hdm:ZigBee:dc8exxxxxxxxxxxx",
        "childDeviceIds": []
    },
    {
        "@type": "device",
        "rootDeviceId": "xx-xx-xx-xx-xx-xx",
        "id": "hdm:ZigBee:dc8exxxxxxxxxxxx#2",
        "deviceServiceIds": [
            "PowerSwitch",
            "ChildProtection",
            "PowerSwitchProgram"
        ],
        "manufacturer": "BOSCH",
        "roomId": "hz_8",
        "deviceModel": "MICROMODULE_LIGHT_ATTACHED",
        "serial": "DC8EXXXXXXXXXXXX",
        "profile": "GENERIC",
        "iconId": "icon_mm_light_generic",
        "name": "test",
        "status": "AVAILABLE",
        "parentDeviceId": "hdm:ZigBee:dc8exxxxxxxxxxxx",
        "childDeviceIds": []
    },
```

This is a configuration for a single connected light:
```
{
        "@type": "device",
        "rootDeviceId": "xx-xx-xx-xx-xx-xx",
        "id": "hdm:ZigBee:dc8exxxxxxxxxxxx#2",
        "deviceServiceIds": [
            "PowerSwitch",
            "ChildProtection",
            "PowerSwitchProgram"
        ],
        "manufacturer": "BOSCH",
        "roomId": "hz_8",
        "deviceModel": "MICROMODULE_LIGHT_ATTACHED",
        "serial": "DC8Exxxxxxxxxxxx",
        "profile": "GENERIC",
        "iconId": "icon_mm_light_generic",
        "name": "test3",
        "status": "AVAILABLE",
        "parentDeviceId": "hdm:ZigBee:dc8exxxxxxxxxxxx",
        "childDeviceIds": []
    },
```

**I'm not sure if the correct deviceModel has to be "MICROMODULE_LIGHT_CONTROL" or "MICROMODULE_LIGHT_ATTACHED".**

I guess that the correct term has to be "MICROMODULE_LIGHT_ATTACHED", so I implemented it that way.
Still, please review / test and correct as needed.

Thanks!