### PR TITLE
Add "Door/window contact II [+M]" support

### DIFF
--- a/boschshcpy/device_helper.py
+++ b/boschshcpy/device_helper.py
@@ -81,6 +81,8 @@ class SHCDeviceHelper:
         devices = []
         if "SWD2" in SUPPORTED_MODELS:
             devices.extend(self._devices_by_model["SWD2"].values())
+        if "SWD2_DUAL" in SUPPORTED_MODELS:
+            devices.extend(self._devices_by_model["SWD2_DUAL"].values())
         if "SWD2_PLUS" in SUPPORTED_MODELS:
             devices.extend(self._devices_by_model["SWD2_PLUS"].values())
         return devices

--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -923,6 +923,7 @@ class SHCMicromoduleDimmer(
 MODEL_MAPPING = {
     "SWD": SHCShutterContact,
     "SWD2": SHCShutterContact2,
+    "SWD2_DUAL": SHCShutterContact2,
     "SWD2_PLUS": SHCShutterContact2Plus,
     "BBL": SHCShutterControl,
     "MICROMODULE_AWNING": SHCMicromoduleShutterControl,


### PR DESCRIPTION
The Rawscan for the Window Contact 2 [+M] resulted in the following output: 

```json
[
  {
    "@type": "device",
    "rootDeviceId": "<rootDeviceId>",
    "id": "hdm:ZigBee:b43a31fffe14993d",
    "deviceServiceIds": [
      "CommunicationQuality",
      "ShutterContact",
      "BatteryLevel",
      "Bypass"
    ],
    "manufacturer": "BOSCH",
    "roomId": "hz_1",
    "deviceModel": "SWD2_DUAL",
    "serial": "B43A31FFFE14993D",
    "profile": "REGULAR_WINDOW",
    "iconId": "icon_tfk_terrace_door",
    "name": "Window contact II [+M]",
    "status": "AVAILABLE",
    "childDeviceIds": [],
    "supportedProfiles": [],
    "installationTimestamp": 1737826985404
  },
  {
    "@type": "DeviceServiceData",
    "id": "Bypass",
    "deviceId": "hdm:ZigBee:b43a31fffe14993d",
    "state": {
      "@type": "bypassState",
      "state": "BYPASS_INACTIVE",
      "configuration": { "enabled": false, "timeout": 5, "infinite": false }
    },
    "path": "/devices/hdm:ZigBee:b43a31fffe14993d/services/Bypass"
  },
  {
    "@type": "DeviceServiceData",
    "id": "ShutterContact",
    "deviceId": "hdm:ZigBee:b43a31fffe14993d",
    "state": { "@type": "shutterContactState", "value": "CLOSED" },
    "path": "/devices/hdm:ZigBee:b43a31fffe14993d/services/ShutterContact"
  },
  {
    "@type": "DeviceServiceData",
    "id": "BatteryLevel",
    "deviceId": "hdm:ZigBee:b43a31fffe14993d",
    "path": "/devices/hdm:ZigBee:b43a31fffe14993d/services/BatteryLevel"
  },
  {
    "@type": "DeviceServiceData",
    "id": "CommunicationQuality",
    "deviceId": "hdm:ZigBee:b43a31fffe14993d",
    "state": { "@type": "communicationQualityState", "quality": "GOOD" },
    "path": "/devices/hdm:ZigBee:b43a31fffe14993d/services/CommunicationQuality"
  }
]

```

It seems to have the same functionalities as ShutterContact2, so I simply added it to the supported models, which worked in my local tests.