### PR TITLE
Add VALVE_TOO_TIGHT state to ValveTappetService

### DIFF
--- a/boschshcpy/services_impl.py
+++ b/boschshcpy/services_impl.py
@@ -283,6 +283,7 @@ class ValveTappetService(SHCDeviceService):
         IN_START_POSITION = "IN_START_POSITION"
         NOT_AVAILABLE = "NOT_AVAILABLE"
         NO_VALVE_BODY_ERROR = "NO_VALVE_BODY_ERROR"
+        VALVE_TOO_TIGHT = "VALVE_TOO_TIGHT"
 
     @property
     def position(self) -> int:


### PR DESCRIPTION
Fixing issue when using Home Assistant HACS integration:

```
  File "/home/homeassistant/.homeassistant/custom_components/bosch_shc/sensor.py", line 499, in extra_state_attributes
    "valve_tappet_state": self._device.valvestate.name,
                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/homeassistant/.homeassistant/lib/python3.13/site-packages/boschshcpy/models_impl.py", line 518, in valvestate
    return self._valvetappet_service.value
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/homeassistant/.homeassistant/lib/python3.13/site-packages/boschshcpy/services_impl.py", line 293, in value
    return self.State(self.state["value"])
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/enum.py", line 726, in __call__
    return cls.__new__(cls, value)
           ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.13/enum.py", line 1199, in __new__
    raise ve_exc
ValueError: 'VALVE_TOO_TIGHT' is not a valid ValveTappetService.State
```