### PR TITLE
Fix urllib3 connection pool size for parallel API access

### DIFF
--- a/boschshcpy/api.py
+++ b/boschshcpy/api.py
@@ -48,7 +48,8 @@ class SHCAPI:
         # Settings for all API calls
         self._requests_session = requests.Session()
         self._requests_session.mount(
-            "https://", HostNameIgnoringAdapter(pool_connections=20)
+            "https://",
+            HostNameIgnoringAdapter(pool_connections=20, pool_maxsize=20),
         )
         self._requests_session.cert = (self._certificate, self._key)
         self._requests_session.headers.update(


### PR DESCRIPTION
Closes #56.

## Summary
Sets `pool_maxsize=20` on the HTTPS adapter so urllib3 stops discarding connections under concurrent SHC access.

## Why
`HostNameIgnoringAdapter(pool_connections=20)` only controls the number of distinct host pools in the `PoolManager`. With a single SHC host that argument is effectively a no-op; the per-pool connection cap (`pool_maxsize`) was left at urllib3's default of **10**.

When ≥3 Home Assistant `SyncWorker_*` threads overlap with the `SHCPollingThread`, urllib3 logs:

```
WARNING (SyncWorker_10) [urllib3.connectionpool] Connection pool is full, discarding connection: <shc-ip>. Pool size: 10
```

Connections beyond 10 are still created and used, but then closed instead of returned to the pool — extra TLS handshakes and log noise.

## Change
```diff
         self._requests_session = requests.Session()
         self._requests_session.mount(
-            "https://", HostNameIgnoringAdapter(pool_connections=20)
+            "https://",
+            HostNameIgnoringAdapter(pool_connections=20, pool_maxsize=20),
         )
```

`pool_maxsize=20` covers the realistic worst case (HA worker pool + polling thread). The existing `HostNameIgnoringAdapter.init_poolmanager` already forwards `maxsize` to `PoolManager`, so no adapter change is needed.

## Test plan
- [x] No new dependencies
- [x] Local Home Assistant 2026.5.2 + boschshcpy patched in place: parallel state updates no longer produce the "Pool size: 10" warning
- [ ] Maintainer review