### PR TITLE
Lower SHC poll-id invalidation logs from WARNING to DEBUG

### DIFF
--- a/boschshcpy/session.py
+++ b/boschshcpy/session.py
@@ -166,8 +166,8 @@ class SHCSession:
         except JSONRPCError as json_rpc_error:
             if json_rpc_error.code == -32001:
                 self._poll_id = None
-                logger.warning(
-                    f"SHC claims unknown poll id. Invalidating poll id and trying resubscribe next time..."
+                logger.debug(
+                    "SHC claims unknown poll id. Invalidating poll id and trying resubscribe next time..."
                 )
                 return False
             else:
@@ -264,9 +264,7 @@ class SHCSession:
                 while not self._stop_polling_thread:
                     try:
                         if not self._long_poll():
-                            logger.warning(
-                                "_long_poll returned False. Waiting 1 second."
-                            )
+                            logger.debug("_long_poll returned False. Waiting 1 second.")
                             time.sleep(1.0)
                     except RuntimeError as err:
                         self._stop_polling_thread = True


### PR DESCRIPTION
Closes #58.

## Summary
The SHC invalidates long-poll subscriptions on a ~24h server-side TTL. The library already recovers cleanly via `RE/subscribe` on the next iteration, but the recovery path was emitting two `WARNING` lines on every occurrence — i.e. once per day per SHC integration, indefinitely.

This PR lowers both lines to `DEBUG`. They remain available when actually debugging the polling loop, but no longer pollute steady-state Home Assistant logs.

## Change
```diff
             if json_rpc_error.code == -32001:
                 self._poll_id = None
-                logger.warning(
-                    f"SHC claims unknown poll id. Invalidating poll id and trying resubscribe next time..."
+                logger.debug(
+                    "SHC claims unknown poll id. Invalidating poll id and trying resubscribe next time..."
                 )
                 return False
```

```diff
                     try:
                         if not self._long_poll():
-                            logger.warning(
-                                "_long_poll returned False. Waiting 1 second."
-                            )
+                            logger.debug("_long_poll returned False. Waiting 1 second.")
                             time.sleep(1.0)
```

Also dropped the unnecessary `f`-prefix on the literal string.

## Why DEBUG and not INFO
The condition is fully recoverable and there is no end-user action required. Anyone investigating the polling loop will already raise the log level; everyone else just sees noise. If you'd prefer a one-shot INFO per session (e.g. on first invalidation), I can change that — let me know.

## Test plan
- [x] Local HA 2026.5.2 with boschshcpy patched in place — no more daily 07:27 WARNING entries
- [x] Polling continues to recover (next poll succeeds without manual intervention)
- [ ] Maintainer review