### PR TITLE
Replace asserts and generic Exception in api.py with typed SHC errors

### DIFF
--- a/boschshcpy/api.py
+++ b/boschshcpy/api.py
@@ -6,7 +6,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager
 
-from .exceptions import SHCSessionError
+from .exceptions import SHCConnectionError, SHCSessionError
 
 logger = logging.getLogger("boschshcpy")
 
@@ -84,17 +84,25 @@ class SHCAPI:
             else:
                 if len(result.content) > 0:
                     result = json.loads(result.content)
-                    if expected_type is not None:
-                        assert result["@type"] == expected_type
+                    if expected_type is not None and result.get("@type") != expected_type:
+                        raise SHCSessionError(
+                            f"Unexpected @type in API response: expected "
+                            f"{expected_type!r}, got {result.get('@type')!r}"
+                        )
                     if expected_element_type is not None:
                         for result_ in result:
-                            assert result_["@type"] == expected_element_type
+                            if result_.get("@type") != expected_element_type:
+                                raise SHCSessionError(
+                                    f"Unexpected @type in API response element: "
+                                    f"expected {expected_element_type!r}, got "
+                                    f"{result_.get('@type')!r}"
+                                )
 
                     return result
                 else:
                     return {}
         except requests.exceptions.SSLError as e:
-            raise Exception(f"API call returned SSLError: {e}.")
+            raise SHCConnectionError(f"API call returned SSLError: {e}.") from e
 
     def _put_api_or_fail(self, api_url, body, timeout=30):
         result = self._requests_session.put(
@@ -201,6 +209,14 @@ class SHCAPI:
         api_url = f"{self._api_root}/{path}"
         self._post_api_or_fail(api_url, body=data)
 
+    @staticmethod
+    def _check_jsonrpc_version(result, method):
+        if result[0].get("jsonrpc") != "2.0":
+            raise SHCSessionError(
+                f"Unexpected JSON-RPC version in {method} response: "
+                f"{result[0].get('jsonrpc')!r}"
+            )
+
     def long_polling_subscribe(self):
         data = [
             {
@@ -210,7 +226,7 @@ class SHCAPI:
             }
         ]
         result = self._post_api_or_fail(self._rpc_root, data)
-        assert result[0]["jsonrpc"] == "2.0"
+        self._check_jsonrpc_version(result, "RE/subscribe")
         if "error" in result[0].keys():
             raise JSONRPCError(
                 result[0]["error"]["code"], result[0]["error"]["message"]
@@ -227,7 +243,7 @@ class SHCAPI:
             }
         ]
         result = self._post_api_or_fail(self._rpc_root, data, wait_seconds + 5)
-        assert result[0]["jsonrpc"] == "2.0"
+        self._check_jsonrpc_version(result, "RE/longPoll")
         if "error" in result[0].keys():
             raise JSONRPCError(
                 result[0]["error"]["code"], result[0]["error"]["message"]
@@ -238,7 +254,7 @@ class SHCAPI:
     def long_polling_unsubscribe(self, poll_id):
         data = [{"jsonrpc": "2.0", "method": "RE/unsubscribe", "params": [poll_id]}]
         result = self._post_api_or_fail(self._rpc_root, data)
-        assert result[0]["jsonrpc"] == "2.0"
+        self._check_jsonrpc_version(result, "RE/unsubscribe")
         if "error" in result[0].keys():
             raise JSONRPCError(
                 result[0]["error"]["code"], result[0]["error"]["message"]


### PR DESCRIPTION
Closes #60.

## Summary
Hardens `boschshcpy/api.py` against two patterns that hurt diagnosability and safety in production:

1. **`assert` statements** gating protocol invariants — silently dropped when Python runs with `-O` / `PYTHONOPTIMIZE=1`, letting malformed SHC responses flow downstream.
2. **`raise Exception(...)`** on SSL errors — masks the connection-error semantics behind a bare `Exception`, so callers cannot react appropriately.

## Changes

### `_get_api_result_or_fail`
- Two `assert result["@type"] == ...` checks become explicit `if/raise SHCSessionError(...)` with descriptive messages that name expected vs. actual `@type`.
- SSL `Exception` is now `raise SHCConnectionError(...) from e`, preserving the original traceback. `SHCConnectionError` is already defined in `exceptions.py`.

### `long_polling_subscribe` / `_poll` / `_unsubscribe`
- The three identical `assert result[0]["jsonrpc"] == "2.0"` lines are replaced by a single `_check_jsonrpc_version()` static helper that raises `SHCSessionError` with a message naming the failing method.

## Why typed exceptions
Home Assistant's `bosch_shc` integration (and presumably others) already handle `SHCSessionError` and `SHCConnectionError` distinctly — auth/protocol errors typically trigger a reload, transient connection errors trigger a retry. Hiding both behind `AssertionError` / bare `Exception` defeats that.

## Test plan
- [x] `python -c \"import ast; ast.parse(open('boschshcpy/api.py').read())\"` — passes
- [x] No new dependencies
- [x] Existing call sites that catch the typed exceptions keep working without change
- [ ] Maintainer review

## Scope notes
This PR intentionally limits the change to `api.py`. Nine more `assert` statements live elsewhere in the package (`device.py`, `device_service.py`, `models_impl.py`, `domain_impl.py`, `services_impl.py`, `session.py`). They are not in the hot network path, so converting them is a separate, less urgent cleanup — happy to follow up if you want them in scope.