### PR TITLE
Add RoomClimateControl cooling mode support using roomControlMode

### DIFF
--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -635,6 +635,14 @@ class SHCClimateControl(_TemperatureLevel):
         self._roomclimatecontrol_service.summer_mode = value
 
     @property
+    def room_control_mode(self) -> str:
+        return self._roomclimatecontrol_service.room_control_mode
+
+    @room_control_mode.setter
+    def room_control_mode(self, value: str):
+        self._roomclimatecontrol_service.room_control_mode = value
+
+    @property
     def cooling_mode(self) -> bool:
         return self._roomclimatecontrol_service.cooling_mode
 

--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -634,6 +634,18 @@ class SHCClimateControl(_TemperatureLevel):
     def summer_mode(self, value: bool):
         self._roomclimatecontrol_service.summer_mode = value
 
+    @property
+    def cooling_mode(self) -> bool:
+        return self._roomclimatecontrol_service.cooling_mode
+
+    @cooling_mode.setter
+    def cooling_mode(self, value: bool):
+        self._roomclimatecontrol_service.cooling_mode = value
+
+    @property
+    def supports_cooling(self) -> bool:
+        return self._roomclimatecontrol_service.supports_cooling
+
 
 class SHCHeatingCircuit(SHCDevice):
     from .services_impl import HeatingCircuitService

--- a/boschshcpy/services_impl.py
+++ b/boschshcpy/services_impl.py
@@ -110,6 +110,18 @@ class RoomClimateControlService(SHCDeviceService):
         self.put_state_element("summerMode", value)
 
     @property
+    def cooling_mode(self) -> bool:
+        return self.state.get("coolingMode", False)
+
+    @cooling_mode.setter
+    def cooling_mode(self, value: bool):
+        self.put_state_element("coolingMode", value)
+
+    @property
+    def supports_cooling(self) -> bool:
+        return "coolingMode" in self.state
+
+    @property
     def supports_boost_mode(self) -> bool:
         return self.state["supportsBoostMode"]
 
@@ -130,6 +142,8 @@ class RoomClimateControlService(SHCDeviceService):
         print(f"    Low                      : {self.low}")
         print(f"    Boost Mode               : {self.boost_mode}")
         print(f"    Summer Mode              : {self.summer_mode}")
+        print(f"    Cooling Mode             : {self.cooling_mode}")
+        print(f"    Supports Cooling         : {self.supports_cooling}")
         print(f"    Supports Boost Mode      : {self.supports_boost_mode}")
         print(f"    Show Setpoint Temperature: {self.show_setpoint_temperature}")
 

--- a/boschshcpy/services_impl.py
+++ b/boschshcpy/services_impl.py
@@ -110,16 +110,24 @@ class RoomClimateControlService(SHCDeviceService):
         self.put_state_element("summerMode", value)
 
     @property
+    def room_control_mode(self) -> str:
+        return self.state.get("roomControlMode", "HEATING")
+
+    @room_control_mode.setter
+    def room_control_mode(self, value: str):
+        self.put_state_element("roomControlMode", value)
+
+    @property
     def cooling_mode(self) -> bool:
-        return self.state.get("coolingMode", False)
+        return self.room_control_mode == "COOLING"
 
     @cooling_mode.setter
     def cooling_mode(self, value: bool):
-        self.put_state_element("coolingMode", value)
+        self.room_control_mode = "COOLING" if value else "HEATING"
 
     @property
     def supports_cooling(self) -> bool:
-        return "coolingMode" in self.state
+        return "roomControlMode" in self.state
 
     @property
     def supports_boost_mode(self) -> bool:
@@ -142,6 +150,7 @@ class RoomClimateControlService(SHCDeviceService):
         print(f"    Low                      : {self.low}")
         print(f"    Boost Mode               : {self.boost_mode}")
         print(f"    Summer Mode              : {self.summer_mode}")
+        print(f"    Room Control Mode        : {self.room_control_mode}")
         print(f"    Cooling Mode             : {self.cooling_mode}")
         print(f"    Supports Cooling         : {self.supports_cooling}")
         print(f"    Supports Boost Mode      : {self.supports_boost_mode}")


### PR DESCRIPTION
This PR adds support for cooling mode in `RoomClimateControlService` and exposes it via `SHCClimateControl`. 

### Changes
- Map `cooling_mode` (boolean getter/setter) to and from the API's `roomControlMode` ("COOLING" vs "HEATING").
- Add `supports_cooling` property checking for the presence of `roomControlMode` in the device service state.
- Expose `cooling_mode` and `supports_cooling` on `SHCClimateControl` model.
- Update `summary()` output to include Room Control Mode and cooling details.

### Testing
- Tested and verified working successfully with my **Bosch Raumthermostat Fußbodenheizung 230V**.

This provides the core API support required to enable cooling in Home Assistant for compatible Bosch thermostats.
