### PR TITLE
Export SHCHeatingCircuit from the package

### DIFF
--- a/boschshcpy/__init__.py
+++ b/boschshcpy/__init__.py
@@ -6,6 +6,7 @@ from .device_helper import (
     SHCCameraOutdoorGen2,
     SHCClimateControl,
     SHCDeviceHelper,
+    SHCHeatingCircuit,
     SHCLight,
     SHCMotionDetector,
     SHCMotionDetector2,


### PR DESCRIPTION
`SHCHeatingCircuit` is defined in `models_impl` and returned by `device_helper.heating_circuits`, but it is not re-exported from the package `__init__`, so `from boschshcpy import SHCHeatingCircuit` fails. This adds it to the public exports alongside the other device classes.

Enables a Heating Circuit climate entity in the HA integration — see the companion PR in tschamm/boschshc-hass.