### PR TITLE
async phase 1: aiohttp + mTLS foundation (SHCAPIAsync)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest flake8
+          pip install pytest flake8 aiohttp  # aiohttp: dev dep for the async (api_async) tests
       - name: Test
         run: pytest tests/ -q
       - name: Lint (informational)

--- a/boschshcpy/api_async.py
+++ b/boschshcpy/api_async.py
@@ -1,0 +1,396 @@
+"""async HTTP layer for boschshcpy — Phase 1 foundation.
+
+NON-BREAKING: importing this module is optional. The sync SHCAPI in api.py is
+untouched. aiohttp is imported lazily inside this module so that
+``import boschshcpy`` remains light when aiohttp is not installed.
+
+mTLS strategy
+-------------
+The Bosch SHC serves its HTTPS endpoints on an IP address whose TLS
+certificate carries neither a matching CN nor a SAN that equals the IP.
+The sync SHCAPI works around this with a custom requests adapter that passes
+``assert_hostname=False`` to urllib3's PoolManager.
+
+The async equivalent is:
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False          # no CN/SAN validation against IP
+    ctx.verify_mode = ssl.CERT_REQUIRED  # but still verify the Bosch CA
+    ctx.load_verify_locations(cafile=<bundled tls_ca_chain.pem>)
+    ctx.load_cert_chain(certfile=certificate, keyfile=key)  # mTLS client cert
+
+This is the aiohttp equivalent of the HostNameIgnoringAdapter pattern and must
+be validated against live SHC hardware before Phase 1 ships (see
+01_analysis/async-phase1-verify.md).
+
+External session
+----------------
+Pass an existing ``aiohttp.ClientSession`` via ``external_session`` to let HA's
+``async_create_clientsession`` manage the lifecycle. When no external session is
+provided, SHCAPIAsync creates and owns its own session; call ``await api.close()``
+when done.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+import logging
+import ssl
+from typing import Any
+
+from .exceptions import SHCConnectionError, SHCSessionError
+
+logger = logging.getLogger("boschshcpy")
+
+# Re-export so callers can ``from boschshcpy.api_async import JSONRPCError``
+# without importing the sync api module.
+from .api import JSONRPCError  # noqa: E402  (after stdlib imports is fine)
+
+
+def build_ssl_context(certificate: str, key: str) -> ssl.SSLContext:
+    """Build an mTLS SSLContext that mirrors the sync HostNameIgnoringAdapter.
+
+    Args:
+        certificate: Path to the PEM client certificate file.
+        key: Path to the PEM private key file.
+
+    Returns:
+        ssl.SSLContext configured for Bosch SHC mTLS:
+        - check_hostname=False  (SHC cert CN/SAN doesn't match its IP)
+        - verify_mode=CERT_REQUIRED  (still pins to the bundled Bosch CA)
+        - client cert + key loaded for mutual TLS
+    """
+    ca_chain = str(importlib.resources.files("boschshcpy") / "tls_ca_chain.pem")
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    # Must be set BEFORE verify_mode so the combination is valid
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.load_verify_locations(cafile=ca_chain)
+    ctx.load_cert_chain(certfile=certificate, keyfile=key)
+    return ctx
+
+
+class SHCAPIAsync:
+    """Async counterpart to the sync SHCAPI.
+
+    Uses ``aiohttp.ClientSession`` + ``aiohttp.TCPConnector`` with the mTLS
+    SSLContext produced by ``build_ssl_context()``.
+
+    Phase 1 scope: all request/response methods are async.
+    The long-poll *thread* is not replaced here — that is Phase 2.
+    The async long_polling_* methods below provide the async POST calls that
+    Phase 2 will use inside an asyncio.Task.
+    """
+
+    def __init__(
+        self,
+        controller_ip: str,
+        certificate: str,
+        key: str,
+        *,
+        external_session: Any | None = None,
+    ) -> None:
+        """Initialise the async API layer.
+
+        Args:
+            controller_ip: IP address of the SHC controller.
+            certificate: Path to the PEM client certificate.
+            key: Path to the PEM private key.
+            external_session: Optional existing ``aiohttp.ClientSession``.  When
+                provided, SHCAPIAsync does NOT create its own session and will
+                NOT close it in ``close()``.  Intended for HA's
+                ``async_create_clientsession(hass)`` pattern (Phase 3).
+        """
+        # Lazy import: boschshcpy stays importable without aiohttp
+        try:
+            import aiohttp
+        except ImportError as exc:
+            raise ImportError(
+                "aiohttp is required for SHCAPIAsync. "
+                "Install it with: pip install aiohttp"
+            ) from exc
+
+        self._controller_ip = controller_ip
+        self._api_root = f"https://{controller_ip}:8444/smarthome"
+        self._public_root = f"https://{controller_ip}:8446/smarthome/public"
+        self._rpc_root = f"https://{controller_ip}:8444/remote/json-rpc"
+
+        self._ssl_ctx = build_ssl_context(certificate, key)
+        self._owns_session = external_session is None
+
+        if self._owns_session:
+            connector = aiohttp.TCPConnector(ssl=self._ssl_ctx)
+            self._session: Any = aiohttp.ClientSession(
+                connector=connector,
+                headers={"api-version": "3.2", "Content-Type": "application/json"},
+            )
+        else:
+            self._session = external_session
+
+        self._headers = {"api-version": "3.2", "Content-Type": "application/json"}
+
+    @property
+    def controller_ip(self) -> str:
+        return self._controller_ip
+
+    async def close(self) -> None:
+        """Close the managed ClientSession (no-op when an external session was provided)."""
+        if self._owns_session and not self._session.closed:
+            await self._session.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _get_api_result_or_fail(
+        self,
+        api_url: str,
+        expected_type: str | None = None,
+        expected_element_type: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        timeout: int = 30,
+    ) -> Any:
+        """Async GET — mirrors sync ``_get_api_result_or_fail``."""
+        import aiohttp
+
+        headers = dict(self._headers)
+        if extra_headers:
+            headers.update(extra_headers)
+
+        try:
+            async with self._session.get(
+                api_url,
+                headers=headers,
+                ssl=self._ssl_ctx,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                if not resp.ok:
+                    await self._process_nok_result(resp)
+
+                content = await resp.read()
+                if len(content) == 0:
+                    return {}
+
+                result = json.loads(content)
+
+                if expected_type is not None and result.get("@type") != expected_type:
+                    raise SHCSessionError(
+                        f"Unexpected @type in API response: expected "
+                        f"{expected_type!r}, got {result.get('@type')!r}"
+                    )
+                if expected_element_type is not None:
+                    for item in result:
+                        if item.get("@type") != expected_element_type:
+                            raise SHCSessionError(
+                                f"Unexpected @type in API response element: "
+                                f"expected {expected_element_type!r}, got "
+                                f"{item.get('@type')!r}"
+                            )
+                return result
+
+        except aiohttp.ClientSSLError as exc:
+            raise SHCConnectionError(f"API call returned SSLError: {exc}.") from exc
+        except aiohttp.ClientConnectionError as exc:
+            raise SHCConnectionError(f"API connection error: {exc}.") from exc
+
+    async def _put_api_or_fail(
+        self,
+        api_url: str,
+        body: Any,
+        timeout: int = 30,
+    ) -> Any:
+        """Async PUT — mirrors sync ``_put_api_or_fail``."""
+        import aiohttp
+
+        try:
+            async with self._session.put(
+                api_url,
+                data=json.dumps(body),
+                headers=self._headers,
+                ssl=self._ssl_ctx,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                if not resp.ok:
+                    await self._process_nok_result(resp)
+                content = await resp.read()
+                return json.loads(content) if content else {}
+
+        except aiohttp.ClientSSLError as exc:
+            raise SHCConnectionError(f"API call returned SSLError: {exc}.") from exc
+        except aiohttp.ClientConnectionError as exc:
+            raise SHCConnectionError(f"API connection error: {exc}.") from exc
+
+    async def _post_api_or_fail(
+        self,
+        api_url: str,
+        body: Any,
+        timeout: int = 30,
+    ) -> Any:
+        """Async POST — mirrors sync ``_post_api_or_fail``."""
+        import aiohttp
+
+        try:
+            async with self._session.post(
+                api_url,
+                data=json.dumps(body),
+                headers=self._headers,
+                ssl=self._ssl_ctx,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                if not resp.ok:
+                    await self._process_nok_result(resp)
+                content = await resp.read()
+                return json.loads(content) if content else {}
+
+        except aiohttp.ClientSSLError as exc:
+            raise SHCConnectionError(f"API call returned SSLError: {exc}.") from exc
+        except aiohttp.ClientConnectionError as exc:
+            raise SHCConnectionError(f"API connection error: {exc}.") from exc
+
+    async def _process_nok_result(self, resp: Any) -> None:
+        """Raise SHCSessionError for non-OK HTTP responses."""
+        try:
+            body = await resp.read()
+        except Exception:
+            body = b""
+        raise SHCSessionError(
+            f"API call returned non-OK result (code {resp.status})!: {body!r}"
+        )
+
+    # ------------------------------------------------------------------
+    # Public API methods (mirror the sync SHCAPI)
+    # ------------------------------------------------------------------
+
+    async def get_information(self) -> Any:
+        api_url = f"{self._api_root}/information"
+        try:
+            return await self._get_api_result_or_fail(api_url)
+        except Exception as exc:
+            logger.error("Failed to get information from SHC controller: %s", exc)
+            return None
+
+    async def get_public_information(self) -> Any:
+        api_url = f"{self._public_root}/information"
+        try:
+            return await self._get_api_result_or_fail(api_url, extra_headers={})
+        except Exception as exc:
+            logger.error("Failed to get public information from SHC controller: %s", exc)
+            return None
+
+    async def get_rooms(self) -> Any:
+        api_url = f"{self._api_root}/rooms"
+        return await self._get_api_result_or_fail(
+            api_url, expected_element_type="room"
+        )
+
+    async def get_scenarios(self) -> Any:
+        api_url = f"{self._api_root}/scenarios"
+        return await self._get_api_result_or_fail(
+            api_url, expected_element_type="scenario"
+        )
+
+    async def get_devices(self) -> Any:
+        api_url = f"{self._api_root}/devices"
+        return await self._get_api_result_or_fail(
+            api_url, expected_element_type="device"
+        )
+
+    async def get_device(self, device_id: str) -> Any:
+        api_url = f"{self._api_root}/devices/{device_id}"
+        return await self._get_api_result_or_fail(api_url, expected_type="device")
+
+    async def get_services(self) -> Any:
+        api_url = f"{self._api_root}/services"
+        return await self._get_api_result_or_fail(
+            api_url, expected_element_type="DeviceServiceData"
+        )
+
+    async def get_device_services(self, device_id: str) -> Any:
+        api_url = f"{self._api_root}/devices/{device_id}/services"
+        return await self._get_api_result_or_fail(api_url)
+
+    async def get_device_service(self, device_id: str, service_id: str) -> Any:
+        api_url = f"{self._api_root}/devices/{device_id}/services/{service_id}"
+        return await self._get_api_result_or_fail(
+            api_url, expected_type="DeviceServiceData"
+        )
+
+    async def put_device_service_state(
+        self, device_id: str, service_id: str, state_update: Any
+    ) -> None:
+        api_url = f"{self._api_root}/devices/{device_id}/services/{service_id}/state"
+        await self._put_api_or_fail(api_url, state_update)
+
+    async def get_domain_intrusion_detection(self) -> Any:
+        api_url = f"{self._api_root}/intrusion/states/system"
+        return await self._get_api_result_or_fail(api_url, expected_type="systemState")
+
+    async def post_domain_action(self, path: str, data: Any = None) -> None:
+        api_url = f"{self._api_root}/{path}"
+        await self._post_api_or_fail(api_url, body=data)
+
+    # ------------------------------------------------------------------
+    # Long-poll methods (Phase 1: async POST calls only — thread not replaced)
+    # Phase 2 will wrap these in asyncio.Task + async retry loop.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_jsonrpc_version(result: list[Any], method: str) -> None:
+        if result[0].get("jsonrpc") != "2.0":
+            raise SHCSessionError(
+                f"Unexpected JSON-RPC version in {method} response: "
+                f"{result[0].get('jsonrpc')!r}"
+            )
+
+    async def long_polling_subscribe(self) -> str:
+        """POST RE/subscribe → returns poll_id string."""
+        data = [
+            {
+                "jsonrpc": "2.0",
+                "method": "RE/subscribe",
+                "params": ["com/bosch/sh/remote/*", None],
+            }
+        ]
+        result = await self._post_api_or_fail(self._rpc_root, data)
+        self._check_jsonrpc_version(result, "RE/subscribe")
+        if "error" in result[0]:
+            raise JSONRPCError(
+                result[0]["error"]["code"], result[0]["error"]["message"]
+            )
+        return result[0]["result"]
+
+    async def long_polling_poll(self, poll_id: str, wait_seconds: int = 30) -> Any:
+        """POST RE/longPoll → returns list of event dicts.
+
+        NOTE (Phase 1): This method is provided for Phase 2 async task usage.
+        The sync long-poll thread in session.py still calls the sync
+        ``SHCAPI.long_polling_poll`` — that thread is NOT replaced until Phase 2.
+        """
+        data = [
+            {
+                "jsonrpc": "2.0",
+                "method": "RE/longPoll",
+                "params": [poll_id, wait_seconds],
+            }
+        ]
+        result = await self._post_api_or_fail(
+            self._rpc_root, data, timeout=wait_seconds + 5
+        )
+        self._check_jsonrpc_version(result, "RE/longPoll")
+        if "error" in result[0]:
+            raise JSONRPCError(
+                result[0]["error"]["code"], result[0]["error"]["message"]
+            )
+        return result[0]["result"]
+
+    async def long_polling_unsubscribe(self, poll_id: str) -> Any:
+        """POST RE/unsubscribe."""
+        data = [{"jsonrpc": "2.0", "method": "RE/unsubscribe", "params": [poll_id]}]
+        result = await self._post_api_or_fail(self._rpc_root, data)
+        self._check_jsonrpc_version(result, "RE/unsubscribe")
+        if "error" in result[0]:
+            raise JSONRPCError(
+                result[0]["error"]["code"], result[0]["error"]["message"]
+            )
+        return result[0]["result"]

--- a/tests/test_api_async.py
+++ b/tests/test_api_async.py
@@ -1,0 +1,424 @@
+"""Tests for boschshcpy.api_async — Phase 1 async HTTP layer.
+
+All tests are offline (no live SHC). aiohttp is mocked via unittest.mock so
+these run in any environment that has aiohttp installed.
+
+Run with:
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_api_async.py -q -o addopts=""
+"""
+
+import asyncio
+import json
+import ssl
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from boschshcpy.api_async import SHCAPIAsync, build_ssl_context
+from boschshcpy.exceptions import SHCConnectionError, SHCSessionError
+
+
+# ---------------------------------------------------------------------------
+# Certificate / key helpers (same pattern as test_certificate.py)
+# ---------------------------------------------------------------------------
+
+def _build_selfsigned_cert_and_key() -> tuple[bytes, bytes]:
+    """Return (cert_pem, key_pem) as separate byte strings."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "SHCTestClient")])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+    return cert_pem, key_pem
+
+
+@pytest.fixture(scope="session")
+def cert_and_key_paths(tmp_path_factory: pytest.TempPathFactory) -> tuple[str, str]:
+    """Write a self-signed cert+key to temp files; return (cert_path, key_path)."""
+    tmp = tmp_path_factory.mktemp("certs")
+    cert_pem, key_pem = _build_selfsigned_cert_and_key()
+    cert_path = tmp / "client.crt"
+    key_path = tmp / "client.key"
+    cert_path.write_bytes(cert_pem)
+    key_path.write_bytes(key_pem)
+    return str(cert_path), str(key_path)
+
+
+# ---------------------------------------------------------------------------
+# build_ssl_context tests
+# ---------------------------------------------------------------------------
+
+class TestBuildSslContext:
+    """Unit tests for build_ssl_context() — no network required."""
+
+    def test_returns_ssl_context(self, cert_and_key_paths: tuple[str, str]) -> None:
+        cert, key = cert_and_key_paths
+        ctx = build_ssl_context(cert, key)
+        assert isinstance(ctx, ssl.SSLContext)
+
+    def test_check_hostname_is_false(self, cert_and_key_paths: tuple[str, str]) -> None:
+        """check_hostname must be False — SHC cert CN/SAN doesn't match its IP."""
+        cert, key = cert_and_key_paths
+        ctx = build_ssl_context(cert, key)
+        assert ctx.check_hostname is False
+
+    def test_verify_mode_is_cert_required(self, cert_and_key_paths: tuple[str, str]) -> None:
+        """verify_mode must be CERT_REQUIRED — still verifies the Bosch CA pin."""
+        cert, key = cert_and_key_paths
+        ctx = build_ssl_context(cert, key)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+    def test_ca_chain_loaded(self, cert_and_key_paths: tuple[str, str]) -> None:
+        """The bundled tls_ca_chain.pem must be loaded (context has CA certs)."""
+        cert, key = cert_and_key_paths
+        # We can't easily inspect loaded CAs, but if load_verify_locations failed
+        # the call above would have raised — check indirectly via get_ca_certs()
+        # which returns an empty list when nothing is loaded.
+        ctx = build_ssl_context(cert, key)
+        # A successfully loaded CA chain returns a non-empty list from get_ca_certs()
+        ca_certs = ctx.get_ca_certs()
+        assert isinstance(ca_certs, list)
+        # The Bosch CA chain PEM is bundled in the package; it must load ≥1 cert.
+        assert len(ca_certs) >= 1, "tls_ca_chain.pem appears to be empty or not loaded"
+
+    def test_client_cert_loaded(self, cert_and_key_paths: tuple[str, str], monkeypatch: pytest.MonkeyPatch) -> None:
+        """Client cert must be loaded; mTLS requires load_cert_chain to succeed."""
+        cert, key = cert_and_key_paths
+        loaded_args: list[Any] = []
+        original_load = ssl.SSLContext.load_cert_chain
+
+        def spy_load_cert_chain(self: ssl.SSLContext, *args: Any, **kwargs: Any) -> None:
+            loaded_args.append((args, kwargs))
+            original_load(self, *args, **kwargs)
+
+        monkeypatch.setattr(ssl.SSLContext, "load_cert_chain", spy_load_cert_chain)
+        build_ssl_context(cert, key)
+        assert len(loaded_args) == 1
+        # certfile is the first positional or keyword argument
+        call_args, call_kwargs = loaded_args[0]
+        certfile = call_args[0] if call_args else call_kwargs.get("certfile")
+        assert certfile == cert
+
+
+# ---------------------------------------------------------------------------
+# Helpers for mocking aiohttp responses
+# ---------------------------------------------------------------------------
+
+def _make_mock_response(
+    status: int = 200,
+    body: Any = None,
+    ok: bool = True,
+) -> MagicMock:
+    """Build a mock that behaves like an aiohttp ClientResponse used as async CM."""
+    body_bytes = json.dumps(body).encode() if body is not None else b""
+    resp = MagicMock()
+    resp.ok = ok
+    resp.status = status
+    resp.read = AsyncMock(return_value=body_bytes)
+    # async context manager support
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+def _make_api(cert_and_key_paths: tuple[str, str]) -> SHCAPIAsync:
+    """Build an SHCAPIAsync with a mocked aiohttp.ClientSession."""
+    cert, key = cert_and_key_paths
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.close = AsyncMock()
+
+    api = SHCAPIAsync.__new__(SHCAPIAsync)
+    api._controller_ip = "192.0.2.1"
+    api._api_root = "https://192.0.2.1:8444/smarthome"
+    api._public_root = "https://192.0.2.1:8446/smarthome/public"
+    api._rpc_root = "https://192.0.2.1:8444/remote/json-rpc"
+    api._ssl_ctx = build_ssl_context(cert, key)
+    api._owns_session = True
+    api._session = mock_session
+    api._headers = {"api-version": "3.2", "Content-Type": "application/json"}
+    return api
+
+
+# ---------------------------------------------------------------------------
+# URL / header construction tests
+# ---------------------------------------------------------------------------
+
+class TestUrlAndHeaders:
+    """Verify that async methods build the correct URLs and pass required headers."""
+
+    def test_get_information_url(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(body={"@type": "None", "apiVersions": []})
+        api._session.get = MagicMock(return_value=resp)
+
+        asyncio.run(api.get_information())
+
+        called_url = api._session.get.call_args[0][0]
+        assert called_url == "https://192.0.2.1:8444/smarthome/information"
+
+    def test_get_devices_url(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(body=[])
+        api._session.get = MagicMock(return_value=resp)
+
+        asyncio.run(api.get_devices())
+
+        called_url = api._session.get.call_args[0][0]
+        assert called_url == "https://192.0.2.1:8444/smarthome/devices"
+
+    def test_get_services_url(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(body=[])
+        api._session.get = MagicMock(return_value=resp)
+
+        asyncio.run(api.get_services())
+
+        called_url = api._session.get.call_args[0][0]
+        assert called_url == "https://192.0.2.1:8444/smarthome/services"
+
+    def test_api_version_header_present(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(body=[])
+        api._session.get = MagicMock(return_value=resp)
+
+        asyncio.run(api.get_devices())
+
+        kwargs = api._session.get.call_args[1]
+        headers = kwargs.get("headers", {})
+        assert headers.get("api-version") == "3.2"
+        assert headers.get("Content-Type") == "application/json"
+
+    def test_put_device_service_state_url(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(body={})
+        api._session.put = MagicMock(return_value=resp)
+
+        asyncio.run(
+            api.put_device_service_state("dev-1", "TemperatureLevel", {"@type": "temperatureLevelState", "temperature": 21.5})
+        )
+
+        called_url = api._session.put.call_args[0][0]
+        assert called_url == (
+            "https://192.0.2.1:8444/smarthome/devices/dev-1/services/TemperatureLevel/state"
+        )
+
+    def test_long_polling_subscribe_url(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(
+            body=[{"jsonrpc": "2.0", "result": "poll-id-abc"}]
+        )
+        api._session.post = MagicMock(return_value=resp)
+
+        poll_id = asyncio.run(api.long_polling_subscribe())
+
+        called_url = api._session.post.call_args[0][0]
+        assert called_url == "https://192.0.2.1:8444/remote/json-rpc"
+        assert poll_id == "poll-id-abc"
+
+    def test_long_polling_poll_url_and_timeout(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(
+            body=[{"jsonrpc": "2.0", "result": [{"@type": "DeviceServiceData"}]}]
+        )
+        api._session.post = MagicMock(return_value=resp)
+
+        result = asyncio.run(api.long_polling_poll("poll-id-xyz", wait_seconds=10))
+
+        called_url = api._session.post.call_args[0][0]
+        assert called_url == "https://192.0.2.1:8444/remote/json-rpc"
+        # Body must encode the poll_id and wait_seconds
+        body_str = api._session.post.call_args[1]["data"]
+        body = json.loads(body_str)
+        assert body[0]["method"] == "RE/longPoll"
+        assert body[0]["params"] == ["poll-id-xyz", 10]
+        assert result == [{"@type": "DeviceServiceData"}]
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+class TestErrorMapping:
+    """Non-OK HTTP responses must map to typed SHCSessionError."""
+
+    def test_non_ok_get_raises_shcsessionerror(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(status=403, body={"message": "Forbidden"}, ok=False)
+        api._session.get = MagicMock(return_value=resp)
+
+        with pytest.raises(SHCSessionError) as exc_info:
+            asyncio.run(api._get_api_result_or_fail("https://192.0.2.1:8444/smarthome/devices"))
+
+        assert "403" in str(exc_info.value)
+
+    def test_non_ok_put_raises_shcsessionerror(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(status=500, ok=False)
+        api._session.put = MagicMock(return_value=resp)
+
+        with pytest.raises(SHCSessionError) as exc_info:
+            asyncio.run(api._put_api_or_fail("https://192.0.2.1:8444/smarthome/x", {}))
+
+        assert "500" in str(exc_info.value)
+
+    def test_non_ok_post_raises_shcsessionerror(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(status=401, ok=False)
+        api._session.post = MagicMock(return_value=resp)
+
+        with pytest.raises(SHCSessionError):
+            asyncio.run(api._post_api_or_fail("https://192.0.2.1:8444/remote/json-rpc", []))
+
+    def test_ssl_error_raises_shcconnectionerror(self, cert_and_key_paths: tuple[str, str]) -> None:
+        import aiohttp
+
+        api = _make_api(cert_and_key_paths)
+        # aiohttp 3.x ClientSSLError(connection_key, os_error)
+        # conn_key must have a .ssl attribute for str() to work
+        conn_key = MagicMock()
+        conn_key.ssl = True
+        ssl_err = aiohttp.ClientSSLError(conn_key, OSError("certificate verify failed"))
+        api._session.get = MagicMock(side_effect=ssl_err)
+
+        with pytest.raises(SHCConnectionError):
+            asyncio.run(api._get_api_result_or_fail("https://192.0.2.1:8444/smarthome/devices"))
+
+    def test_connection_error_raises_shcconnectionerror(self, cert_and_key_paths: tuple[str, str]) -> None:
+        import aiohttp
+
+        api = _make_api(cert_and_key_paths)
+        conn_err = aiohttp.ClientConnectionError("refused")
+        api._session.get = MagicMock(side_effect=conn_err)
+
+        with pytest.raises(SHCConnectionError):
+            asyncio.run(api._get_api_result_or_fail("https://192.0.2.1:8444/smarthome/devices"))
+
+    def test_unexpected_type_raises_shcsessionerror(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(body={"@type": "wrong"})
+        api._session.get = MagicMock(return_value=resp)
+
+        with pytest.raises(SHCSessionError, match="Unexpected @type"):
+            asyncio.run(
+                api._get_api_result_or_fail(
+                    "https://192.0.2.1:8444/smarthome/information",
+                    expected_type="systemState",
+                )
+            )
+
+    def test_jsonrpc_error_in_subscribe_raises(self, cert_and_key_paths: tuple[str, str]) -> None:
+        from boschshcpy.api import JSONRPCError
+
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(
+            body=[{"jsonrpc": "2.0", "error": {"code": -32001, "message": "stale poll"}}]
+        )
+        api._session.post = MagicMock(return_value=resp)
+
+        with pytest.raises(JSONRPCError) as exc_info:
+            asyncio.run(api.long_polling_subscribe())
+
+        assert exc_info.value.code == -32001
+
+    def test_jsonrpc_error_in_poll_raises(self, cert_and_key_paths: tuple[str, str]) -> None:
+        from boschshcpy.api import JSONRPCError
+
+        api = _make_api(cert_and_key_paths)
+        resp = _make_mock_response(
+            body=[{"jsonrpc": "2.0", "error": {"code": -32001, "message": "Unknown poll id"}}]
+        )
+        api._session.post = MagicMock(return_value=resp)
+
+        with pytest.raises(JSONRPCError) as exc_info:
+            asyncio.run(api.long_polling_poll("stale-id"))
+
+        assert exc_info.value.code == -32001
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle / session management tests
+# ---------------------------------------------------------------------------
+
+class TestLifecycle:
+    """Session creation, close, and external-session passthrough."""
+
+    def test_close_owned_session(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        api._owns_session = True
+        asyncio.run(api.close())
+        api._session.close.assert_awaited_once()
+
+    def test_close_external_session_not_called(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        api._owns_session = False
+        asyncio.run(api.close())
+        api._session.close.assert_not_awaited()
+
+    def test_controller_ip_property(self, cert_and_key_paths: tuple[str, str]) -> None:
+        api = _make_api(cert_and_key_paths)
+        assert api.controller_ip == "192.0.2.1"
+
+
+# ---------------------------------------------------------------------------
+# Import safety: boschshcpy importable without touching aiohttp at import time
+# ---------------------------------------------------------------------------
+
+class TestImportSafety:
+    """Ensure importing boschshcpy does NOT require aiohttp."""
+
+    def test_boschshcpy_imports_without_aiohttp(self) -> None:
+        """boschshcpy package must import cleanly even if aiohttp is absent."""
+        import importlib
+        import sys
+
+        # Temporarily hide aiohttp from sys.modules
+        aiohttp_backup = sys.modules.pop("aiohttp", None)
+        try:
+            # Reload boschshcpy top-level — must not crash
+            import boschshcpy
+            importlib.reload(boschshcpy)
+        finally:
+            if aiohttp_backup is not None:
+                sys.modules["aiohttp"] = aiohttp_backup
+
+    def test_api_async_import_without_aiohttp_import_error(self, cert_and_key_paths: tuple[str, str]) -> None:
+        """Constructing SHCAPIAsync without aiohttp installed must raise ImportError.
+
+        The lazy import inside __init__ means we can simulate absence by
+        patching the builtins import so 'import aiohttp' raises ImportError.
+        """
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "aiohttp":
+                raise ImportError("No module named 'aiohttp'")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with pytest.raises(ImportError, match="aiohttp"):
+                SHCAPIAsync("192.0.2.1", "cert.pem", "key.pem")


### PR DESCRIPTION
Non-breaking async foundation, live-verified against a real SHC (aiohttp mTLS GET /information → HTTP 200 with check_hostname=False + custom CA + client cert). Sync api.py untouched; aiohttp imported lazily. Not wired into anything yet — foundation for phase 2. 25 offline tests + a live-verification checklist.