### PR TITLE
Add `supports_eco` capability and make eco/comfort setpoints None-safe for room climate controls

### DIFF
--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -631,6 +631,10 @@ class SHCClimateControl(_TemperatureLevel):
         return self._roomclimatecontrol_service.supports_boost_mode
 
     @property
+    def supports_eco(self) -> bool:
+        return self._roomclimatecontrol_service.supports_eco
+
+    @property
     def low(self) -> bool:
         return self._roomclimatecontrol_service.low
 

--- a/boschshcpy/services_impl.py
+++ b/boschshcpy/services_impl.py
@@ -74,12 +74,14 @@ class RoomClimateControlService(SHCDeviceService):
         self.put_state_element("setpointTemperature", value)
 
     @property
-    def setpoint_temperature_eco(self) -> float:
-        return float(self.state["setpointTemperatureForLevelEco"])
+    def setpoint_temperature_eco(self) -> float | None:
+        value = self.state.get("setpointTemperatureForLevelEco")
+        return float(value) if value is not None else None
 
     @property
-    def setpoint_temperature_comfort(self) -> float:
-        return float(self.state["setpointTemperatureForLevelComfort"])
+    def setpoint_temperature_comfort(self) -> float | None:
+        value = self.state.get("setpointTemperatureForLevelComfort")
+        return float(value) if value is not None else None
 
     @property
     def ventilation_mode(self) -> bool:
@@ -132,6 +134,10 @@ class RoomClimateControlService(SHCDeviceService):
     @property
     def supports_boost_mode(self) -> bool:
         return self.state.get("supportsBoostMode", False)
+
+    @property
+    def supports_eco(self) -> bool:
+        return "setpointTemperatureForLevelEco" in self.state
 
     @property
     def show_setpoint_temperature(self) -> bool:


### PR DESCRIPTION
## Summary

Adds a `supports_eco` property to `RoomClimateControlService` (and a passthrough on `SHCClimateControl`), and makes the existing `setpoint_temperature_eco` / `setpoint_temperature_comfort` getters tolerant of devices that do not expose those fields.

## Why

Not all room climate controls expose the ECO/COMFORT temperature-level model. The controller only emits `setpointTemperatureForLevelEco` / `setpointTemperatureForLevelComfort` for devices that actually implement it (these come with a temperature schedule using `ECO` / `COMFORT` switch points). Other room climate controls model "eco" only through the boolean `low` flag and never send an eco setpoint at all.

Two concrete problems follow from this today:

1. **Latent `KeyError` on real devices.** `setpoint_temperature_eco` and `setpoint_temperature_comfort` read the state dict with hard subscripting (`self.state["setpointTemperatureForLevelEco"]`). On devices that do not send these fields, any access raises `KeyError`. `summary()` calls both unconditionally, so it crashes on those devices.

2. **No way for consumers to know whether eco is meaningful.** Downstream (e.g. the Home Assistant integration) currently offers an "eco" preset unconditionally. On devices without an eco setpoint, toggling `low` has no observable effect, which is confusing for users.

There is no `supportsEco`-style flag in the API state (unlike `supportsBoostMode`), so the only reliable signal is the presence of the eco setpoint field itself.

## Evidence

Both variants are observable in real `boschshc_rawscan` output:

- A `ROOM_CLIMATE_CONTROL` device that **does** implement the level model (rawscan in tschamm/boschshc-hass#70) reports:
  ```json
  "operationMode": "MANUAL",
  "setpointTemperature": 5.0,
  "setpointTemperatureForLevelEco": 17.0,
  "setpointTemperatureForLevelComfort": 21.0,
  "schedule": { "...": "ECO / COMFORT switch points" }
  ```

- A newer `ROOM_CLIMATE_CONTROL` variant (Smart Home Controller II, floor heating) reports neither eco nor comfort setpoint, and instead carries `low`, `roomControlMode`, and `boostMode`:
  ```json
  "operationMode": "AUTOMATIC",
  "setpointTemperature": 21,
  "low": false,
  "boostMode": false,
  "supportsBoostMode": false,
  "roomControlMode": "COOLING"
  ```

## Changes

**`boschshcpy/services_impl.py`** — `RoomClimateControlService`:
- `setpoint_temperature_eco` and `setpoint_temperature_comfort` now use `self.state.get(...)` and return `None` when the field is absent (type hint widened to `float | None`).
- New `supports_eco` property: `return "setpointTemperatureForLevelEco" in self.state`.

**`boschshcpy/models_impl.py`** — `SHCClimateControl`:
- New `supports_eco` passthrough to the underlying service.

## Backwards compatibility

- `supports_eco` is purely additive.
- The getter change is backwards compatible for callers that already guarded against missing fields; callers that previously relied on a `KeyError` (there should be none) would now receive `None`. `summary()` prints `None` instead of crashing.

## Testing

Verified `supports_eco` against both rawscan variants above: returns `True` for the device exposing `setpointTemperatureForLevelEco`, `False` for the device that does not. `setpoint_temperature_eco` / `_comfort` return `None` instead of raising on devices without those fields, and `summary()` no longer crashes.

## Related

This change is consumed by a companion PR in the integration repo, **tschamm/boschshc-hass** (climate platform rework), which:
- maps the Bosch room climate control's two independent axes — direction (`roomControlMode`: heating/cooling/off) and regulation (`operationMode`: automatic/manual) — onto `hvac_mode` + `preset_mode` instead of collapsing both into `hvac_mode` (this makes the previously unreachable "cooling + automatic" state representable);
- gates the eco preset on `device.supports_eco` introduced here (with a `getattr` fallback for older boschshcpy versions);
- bumps the `boschshcpy` minimum version in `manifest.json` to the release containing this change.

Suggested merge order: release this library change first, then bump the requirement in the integration PR. Link to the companion PR to be added once opened.