### PR TITLE
Make eco/comfort setpoint getters None-safe and add supports_eco

### DIFF
--- a/boschshcpy/models_impl.py
+++ b/boschshcpy/models_impl.py
@@ -1318,6 +1318,10 @@ class SHCClimateControl(_TemperatureLevel):
         return self._roomclimatecontrol_service.supports_low
 
     @property
+    def supports_eco(self) -> bool:
+        return self._roomclimatecontrol_service.supports_eco
+
+    @property
     def summer_mode(self) -> bool:
         return self._roomclimatecontrol_service.summer_mode
 

--- a/boschshcpy/services_impl.py
+++ b/boschshcpy/services_impl.py
@@ -74,12 +74,14 @@ class RoomClimateControlService(SHCDeviceService):
         self.put_state_element("setpointTemperature", value)
 
     @property
-    def setpoint_temperature_eco(self) -> float:
-        return float(self.state["setpointTemperatureForLevelEco"])
+    def setpoint_temperature_eco(self) -> float | None:
+        value = self.state.get("setpointTemperatureForLevelEco")
+        return float(value) if value is not None else None
 
     @property
-    def setpoint_temperature_comfort(self) -> float:
-        return float(self.state["setpointTemperatureForLevelComfort"])
+    def setpoint_temperature_comfort(self) -> float | None:
+        value = self.state.get("setpointTemperatureForLevelComfort")
+        return float(value) if value is not None else None
 
     @property
     def ventilation_mode(self) -> bool:
@@ -97,6 +99,14 @@ class RoomClimateControlService(SHCDeviceService):
     def supports_low(self) -> bool:
         # The eco/reduced "low" field is only present on rooms that expose it.
         return "low" in self.state
+
+    @property
+    def supports_eco(self) -> bool:
+        # True only when the controller sends a dedicated eco setpoint, meaning
+        # the room implements the ECO/COMFORT level model with a temperature
+        # schedule.  Devices that have "low" but no eco setpoint (e.g. floor
+        # heating via SHC-II) do not support an eco temperature preset.
+        return "setpointTemperatureForLevelEco" in self.state
 
     @property
     def boost_mode(self) -> bool:
@@ -204,16 +214,18 @@ class HeatingCircuitService(SHCDeviceService):
         self.put_state_element("setpointTemperature", value)
 
     @property
-    def setpoint_temperature_eco(self) -> float:
-        return float(self.state["setpointTemperatureForLevelEco"])
+    def setpoint_temperature_eco(self) -> float | None:
+        value = self.state.get("setpointTemperatureForLevelEco")
+        return float(value) if value is not None else None
 
     @setpoint_temperature_eco.setter
     def setpoint_temperature_eco(self, value: float):
         self.put_state_element("setpointTemperatureForLevelEco", value)
 
     @property
-    def setpoint_temperature_comfort(self) -> float:
-        return float(self.state["setpointTemperatureForLevelComfort"])
+    def setpoint_temperature_comfort(self) -> float | None:
+        value = self.state.get("setpointTemperatureForLevelComfort")
+        return float(value) if value is not None else None
 
     @setpoint_temperature_comfort.setter
     def setpoint_temperature_comfort(self, value: float):


### PR DESCRIPTION
On room climate controls that don't implement the ECO/COMFORT level model (e.g. SHC-II floor-heating rooms), `setpointTemperatureForLevelEco` / `setpointTemperatureForLevelComfort` are absent from the device state. Both `RoomClimateControlService` and `HeatingCircuitService` hard-key into `self.state` and raise `KeyError` on those devices; `summary()` calls both unconditionally and crashes.

## Changes

**`boschshcpy/services_impl.py`**

- `RoomClimateControlService.setpoint_temperature_eco` and `setpoint_temperature_comfort`: switch from `self.state[...]` to `self.state.get(...)`, return `float | None`.
- `HeatingCircuitService.setpoint_temperature_eco` and `setpoint_temperature_comfort`: same fix. Setters are unchanged.
- New `RoomClimateControlService.supports_eco`: `return "setpointTemperatureForLevelEco" in self.state`.

**`boschshcpy/models_impl.py`**

- New `SHCClimateControl.supports_eco` passthrough.

## Why `supports_eco` in addition to `supports_low`

`supports_low` checks `"low" in self.state`. Floor-heating rooms on SHC-II also carry the `"low"` field (value `false`), so `supports_low` returns `True` for them — yet they have no eco setpoint and toggling `low` has no observable effect. `supports_eco` keys off the eco setpoint field itself, which is the only reliable signal that the ECO/COMFORT level model is actually implemented. Consumers can use `supports_eco` to gate the eco preset correctly.

## Backwards compatibility

- Getter change: callers that previously received a `KeyError` (there should be none) now receive `None`. Devices that do expose the fields behave identically.
- `supports_eco` is purely additive.

## Testing

Verified with two mock states — classic radiator (with eco setpoints) and floor-heating room (with `"low"` but without eco setpoints):

| | `supports_eco` | `supports_low` | `setpoint_temperature_eco` |
|---|---|---|---|
| Radiator with eco | `True` | `True` | `16.0` |
| Floor heating | `False` | `True` | `None` (no `KeyError`) |

`HeatingCircuitService` getters return `None` instead of raising on a state dict without the eco fields. `summary()` prints `None` — no crash.

## Related

Closes the getter/`summary()` crash path left open after #67. Display-side gating via `supports_eco` supersedes `supports_low` for the eco preset specifically.