### PR TITLE
Surface ruff/mypy findings as inline PR annotations

### DIFF
--- a/.github/matchers/mypy.json
+++ b/.github/matchers/mypy.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "mypy",
+      "pattern": [
+        {
+          "regexp": "^(.+?):(\\d+):(?:(\\d+):)?\\s+(error|warning|note):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,14 @@ jobs:
         # Matches the ruff settings used in boschshc-hass and local-ci.sh so
         # both repos stay in sync. F401 ignored: __init__.py has intentional
         # re-export imports that ruff would otherwise flag.
+        # github format surfaces violations as inline PR annotations.
         run: |
           pip install ruff
-          ruff check --select=E,W,F --ignore=E501,F401 boschshcpy
+          ruff check --output-format=github --select=E,W,F --ignore=E501,F401 boschshcpy
       - name: Lint — ruff format (gate)
         run: ruff format --check boschshcpy
       - name: Type check
-        run: mypy boschshcpy/
+        run: |
+          echo "::add-matcher::.github/matchers/mypy.json"
+          mypy boschshcpy/
+          echo "::remove-matcher owner=mypy::"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__
 .env
 *.pem
 *.json
+!.github/matchers/*.json


### PR DESCRIPTION
Same change as tschamm/boschshc-hass#357: ruff's built-in \`--output-format=github\` plus a GitHub Actions problem matcher for mypy, so findings show up inline on the PR diff instead of only in the raw job log. No new third-party actions or secrets. Verified the annotation format locally against real ruff/mypy output before opening this.